### PR TITLE
Changed socket event from 'end' to 'close'

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -43,7 +43,7 @@ class StompSocketStreamLayer implements StompStreamLayer {
         log.debug("StompSocketStreamLayer: new connection %s", socket.remoteAddress);
         this.socket.on('data', (data) => this.onSocketData(data));
         this.socket.on('error', (err) => this.onSocketEnd(err));
-        this.socket.on('end', () => this.onSocketEnd());
+        this.socket.on('close', () => this.onSocketEnd());
     }
 
     private onSocketData(data: Buffer) {

--- a/test/e2eTests.ts
+++ b/test/e2eTests.ts
@@ -5,7 +5,7 @@ import {
 } from '../src/protocol'
 import { createStompServerSession, createStompClientSession } from '../src/index';
 import { countdownLatch, noopFn, noopAsyncFn } from './helpers';
-import { createServer, Server, createConnection, Socket } from 'net';
+import { createServer, Server, createConnection, Socket, AddressInfo } from 'net';
 import * as WebSocket from 'ws';
 
 describe('STOMP Client & Server over Plain Socket', () => {
@@ -30,7 +30,7 @@ describe('STOMP Client & Server over Plain Socket', () => {
         });
         server.listen();
         server.on('listening', () => {
-            const port = server.address().port;
+            const port = (server.address() as AddressInfo).port;
             clientSocket = createConnection(port, 'localhost', done);
             clientSession = createStompClientSession(clientSocket, serverListener);
         });


### PR DESCRIPTION
In a Enviroment with HA-Proxy the connection between client/server consist of two connection client-HAProxy and HAProxy-server.
To test the healthiness of the underlying TCP connections and to make sure that the remote client is alive i use the heartbeat.

These are my heartbeat parameters:


```
const clientConfig: StompConfig = {
            heartbeat: {
                outgoingPeriod: 10000,
                incomingPeriod: 0
            },
        };

const serverConfig: StompConfig = {
                heartbeat: {
                    outgoingPeriod: 0,
                    incomingPeriod: 10000
                }
            }; 
```


When the client disconnects, the other connection HAProxy-server keeps alive for 5 minutes (configuration).

The library emit 'ProtocolError' and the method StompSocketStreamLayer.onSocketEnd is not called because the event 'end' on socket is not fired.

Changing the event on socket from 'end' to 'close' works fine.